### PR TITLE
Skip WP Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ sites:
             delete_default_plugins: true
             delete_default_themes: true
             wp-content: https://github.com/jquery/jquery-wp-content.git
+            wp: true
 
 ```
 
@@ -156,3 +157,9 @@ Using this option prevent the following options from having any effect:
 * `plugins`
 * `delete_default_plugins`
 * `delete_default_themes`
+
+### `wp`
+
+Whether to do any WordPress setup whatsoever. Defaults (naturally) to `true`.
+
+If you're going to be building a non-WordPress local site, or if you have a very custom WordPress setup to install, this will skip the automation around downloading, configuring, and installing WordPress.

--- a/src/Provisioner.php
+++ b/src/Provisioner.php
@@ -54,6 +54,12 @@ class Provisioner
         $this->createLogs();
         $this->createBaseDir();
         $this->createNginxConfig();
+
+        if (!$this->site['wp']) {
+            echo "Skipping WordPress setup.\n\n";
+            return;
+        }
+
         $this->downloadWordPress();
         $this->createWpConfig();
         $this->installWordPress();
@@ -99,6 +105,7 @@ class Provisioner
                 'delete_default_plugins' => false,
                 'delete_default_themes'  => false,
                 'wp-content'             => false,
+                'wp'                     => true,
             )
         );
 

--- a/src/Provisioner.php
+++ b/src/Provisioner.php
@@ -53,9 +53,9 @@ class Provisioner
         $this->createDB();
         $this->createLogs();
         $this->createBaseDir();
+        $this->createNginxConfig();
         $this->downloadWordPress();
         $this->createWpConfig();
-        $this->createNginxConfig();
         $this->installWordPress();
         $this->cloneWpContent();
 


### PR DESCRIPTION
Allow for entirely skipping the download, configuration, and installation of WordPress.

Fixes #4 and fixes #5.