### PR TITLE
Fixes locale and dbprefix being ignored 

### DIFF
--- a/src/Provisioner.php
+++ b/src/Provisioner.php
@@ -334,8 +334,6 @@ PHP;
             return;
         }
 
-        echo "Using locale: ".$this->site['locale'];
-        echo "Using version: ".$this->site['version'];
         echo $this->getCmd(
             array('wp', 'core', 'download'),
             array(

--- a/src/Provisioner.php
+++ b/src/Provisioner.php
@@ -110,7 +110,7 @@ class Provisioner
                 'admin_password'         => 'password',
                 'admin_email'            => 'admin@localhost.local',
                 'title'                  => 'My Awesome VVV Site',
-                'prefix'                 => 'wp_',
+                'dbprefix'               => 'wp_',
                 'multisite'              => false,
                 'xipio'                  => true,
                 'version'                => 'latest',
@@ -280,8 +280,8 @@ PHP;
                 'dbuser'    => 'wp',
                 'dbpass'    => 'wp',
                 'dbhost'    => 'localhost',
-                'dbprefix'  => $this->site['prefix'],
-                'locale'    => 'en_US',
+                'dbprefix'  => $this->site['dbprefix'],
+                'locale'    => $this->site['locale'],
                 'extra-php' => $extra_php,
             )
         )->mustRun()->getOutput();
@@ -334,6 +334,8 @@ PHP;
             return;
         }
 
+        echo "Using locale: ".$this->site['locale'];
+        echo "Using version: ".$this->site['version'];
         echo $this->getCmd(
             array('wp', 'core', 'download'),
             array(


### PR DESCRIPTION
Resolves #20 and also `dbprefix` being ignored in config file.
In config file, we must change `db_prefix` to `dbprefix` to match the code and keep consistent naming (like `dbname`).